### PR TITLE
Bugfix for version detection

### DIFF
--- a/src/PlayX/lua/playx/playx.lua
+++ b/src/PlayX/lua/playx/playx.lua
@@ -694,10 +694,10 @@ timer.Adjust("PlayXAdminTimeout", 1, 1, function()
 end)
 
 local folderName = string.match(debug.getinfo(1, "S").short_src, "addons[/\\]([^/\\]+)")
-if not file.Exists("../addons/" .. folderName .. "/info.txt") then folderName = "PlayX" end
+if not file.Exists("addons/" .. folderName .. "/info.txt", true) then folderName = "PlayX" end
 -- Get version
-if file.Exists("../addons/" .. folderName .. "/info.txt") then
-    local contents = file.Read("../addons/" .. folderName .. "/info.txt")
+if file.Exists("addons/" .. folderName .. "/info.txt", true) then
+    local contents = file.Read("addons/" .. folderName .. "/info.txt", true)
     _version = string.match(contents, "\"version\"[ \t]*\"([^\"]+)\"")
     if _version == nil then
         _version = ""


### PR DESCRIPTION
Hi, thx for your good work in playX.

I just fixed a small bug in version detection which stopped working. It was caused by using a wrong path to info.txt leading into nil error that showed up in the console during map load. Maybe its because the usage of file.read was changed a while ago, changing the directory upwards with '../' like you did, didn't work on my Windows Server or garry blocked it maybe. He implemented a new parameter called 'usebasefolder' instead on file.read().
