### PR TITLE
Changed FindMatch table to allow for https URIs.

### DIFF
--- a/src/PlayX/lua/playx/providers/youtube.lua
+++ b/src/PlayX/lua/playx/providers/youtube.lua
@@ -23,12 +23,12 @@ local YouTube = {}
 
 function YouTube.Detect(uri)    
     local m = playxlib.FindMatch(uri, {
-        "^http://youtu%.be/([A-Za-z0-9_%-]+)",
-        "^http://youtube%.com/watch%?.*v=([A-Za-z0-9_%-]+)",
-        "^http://[A-Za-z0-9%.%-]*%.youtube%.com/watch%?.*v=([A-Za-z0-9_%-]+)",
-        "^http://[A-Za-z0-9%.%-]*%.youtube%.com/v/([A-Za-z0-9_%-]+)",
-        "^http://youtube%-nocookie%.com/watch%?.*v=([A-Za-z0-9_%-]+)",
-        "^http://[A-Za-z0-9%.%-]*%.youtube%-nocookie%.com/watch%?.*v=([A-Za-z0-9_%-]+)",
+        "^https?://youtu%.be/([A-Za-z0-9_%-]+)",
+        "^https?://youtube%.com/watch%?.*v=([A-Za-z0-9_%-]+)",
+        "^https?://[A-Za-z0-9%.%-]*%.youtube%.com/watch%?.*v=([A-Za-z0-9_%-]+)",
+        "^https?://[A-Za-z0-9%.%-]*%.youtube%.com/v/([A-Za-z0-9_%-]+)",
+        "^https?://youtube%-nocookie%.com/watch%?.*v=([A-Za-z0-9_%-]+)",
+        "^https?://[A-Za-z0-9%.%-]*%.youtube%-nocookie%.com/watch%?.*v=([A-Za-z0-9_%-]+)",
     })
     
     if m then


### PR DESCRIPTION
The original playx didn't allow for youtube URIs with https instead of http.
I added an s? after each http to allow for the possibility of an s.
There is the possibility that this may mislead players into thinking that their connection is then over https. However, it is also a possibility that a message prompt be displayed when and if the url is https informing the player and giving the option to continue but use http or cancel.
